### PR TITLE
Policies and tokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ notifications:
     on_success: never
 before_script:
 - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
-- VAULT_ADDR=http://127.0.0.1:8200 vault token-create -id="test12345"
+- VAULT_ADDR=http://127.0.0.1:8200 vault token-create -id="test12345" -ttl="720h"
 install:
 - bin/install-vault-${VAULT_BRANCH}.sh
 - export PATH=$HOME/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -3,11 +3,18 @@
 
 [HashiCorp](https://hashicorp.com/) [Vault](https://www.vaultproject.io) API client for Rust.
 
+You can start a local test server running using:
+
 ```bash
 vault server -dev
 ```
 
+Record the `Root Token:` printed at startup time, and use it to create a
+test token:
+
 ```bash
+export VAULT_ADDR=http://localhost:8200
+export VAULT_TOKEN=<root token from server startup>
 vault token-create -id="test12345"
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ test token:
 ```bash
 export VAULT_ADDR=http://localhost:8200
 export VAULT_TOKEN=<root token from server startup>
-vault token-create -id="test12345"
+vault token-create -id="test12345" -ttl="720h"
 ```
 
 ## High Availability

--- a/bin/install-vault-release.sh
+++ b/bin/install-vault-release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux
 
-VAULT_VERSION=${VAULT_VERSION:-0.4.1}
+VAULT_VERSION=${VAULT_VERSION:-0.6.1}
 
 mkdir -p $HOME/bin
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -129,7 +129,7 @@ pub struct Auth {
     /// Client token id
     pub client_token: String,
     /// Accessor
-    pub accessor: String,
+    pub accessor: Option<String>,
     /// Policies
     pub policies: Vec<String>,
     /// Metadata

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -133,7 +133,7 @@ pub struct Auth {
     /// Policies
     pub policies: Vec<String>,
     /// Metadata
-    pub metadata: HashMap<String, String>,
+    pub metadata: Option<HashMap<String, String>>,
     /// Lease duration
     pub lease_duration: Option<VaultDuration>,
     /// True if renewable


### PR DESCRIPTION
Thank you for suggesting that I submit a PR! This PR contains a number of related changes, but each patch makes one, discrete change, and each patch has an explanation of why that change was made in the commit message. So it should be possible to step through the individual patches when reviewing.

This PR includes implementations of two-thirds of the APIs proposed in #5, including:
- Renewing arbitrary auth tokens (using `renew_token`), not just the client's own token (using `renew`). It's important to keep the existing API separate and not reimplement it terms of `renew/$TOKEN`, because some tokens have access to `renew-self` but not `renew/$TOKEN`.
- Listing the policies supported by vault. This normally requires `root` permission, but can be enabled using `sudo` policies if you're clever.

**Not yet implemented** in this PR:
- Creating new tokens. This API will require a lot of optional parameters, which we'll probably want to pass using a `Builder`-style struct. I'll work on this in the coming days.

Also included in this PR:
- Some minor updates and notes to help support Vault 0.6.1, and to make it easier for people to test against it. One of these changes **breaks API compatibility for the `Auth` struct**, so you may need to bump semver when you make a release.
- A bug fix for several existing APIs that I noticed while working on the new features. I've added doc tests for all the APIs that had this bug.

Please feel free to suggest changes and improvements to this patch! And thank you for taking the time to review it.
