### PR TITLE
Create token

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -591,7 +591,7 @@ impl<'a, T> VaultClient<'a, T>
         let body = try!(json::encode(opts));
         let mut res = try!(self.post("/v1/auth/token/create", Some(&body)));
         let vault_res: VaultResponse<()> = try!(parse_vault_response(&mut res));
-        vault_res.auth.ok_or_else(|| Error::Vault("Created token did not include data".into()))
+        vault_res.auth.ok_or_else(|| Error::Vault("Created token did not include auth data".into()))
     }
 
     ///

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -35,17 +35,17 @@ impl VaultDuration {
 
     /// Construct a duration from some number of minutes.
     pub fn minutes(m: u64) -> VaultDuration {
-        VaultDuration::seconds(m*60)
+        VaultDuration::seconds(m * 60)
     }
 
     /// Construct a duration from some number of hours.
     pub fn hours(h: u64) -> VaultDuration {
-        VaultDuration::minutes(h*60)
+        VaultDuration::minutes(h * 60)
     }
 
     /// Construct a duration from some number of days.
     pub fn days(d: u64) -> VaultDuration {
-        VaultDuration::hours(d*24)
+        VaultDuration::hours(d * 24)
     }
 }
 
@@ -303,7 +303,7 @@ impl TokenOptions {
     /// vault.
     pub fn policies<'a, I>(mut self, policies: I) -> Self
         where I: IntoIterator,
-              I::Item: Into<String>,
+              I::Item: Into<String>
     {
         self.policies = Some(policies.into_iter().map(|p| p.into()).collect());
         self
@@ -591,9 +591,7 @@ impl<'a, T> VaultClient<'a, T>
         let body = try!(json::encode(opts));
         let mut res = try!(self.post("/v1/auth/token/create", Some(&body)));
         let vault_res: VaultResponse<()> = try!(parse_vault_response(&mut res));
-        vault_res.auth.ok_or_else(|| {
-            Error::Vault("Created token did not include data".into())
-        })
+        vault_res.auth.ok_or_else(|| Error::Vault("Created token did not include data".into()))
     }
 
     ///

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -480,14 +480,16 @@ impl<'a, T> VaultClient<'a, T>
     ///
     /// ```
     /// # extern crate hashicorp_vault as vault;
-    /// # use vault::Client;
+    /// # use vault::{client, Client};
     /// # fn main() {
     /// let host = "http://127.0.0.1:8200";
     /// let token = "test12345";
     /// let client = Client::new(host, token).unwrap();
     ///
     /// // Create a temporary token, and use it to create a new client.
-    /// let res = client.create_token(&Default::default()).unwrap();
+    /// let opts = client::TokenOptions::default()
+    ///   .ttl(client::VaultDuration::minutes(5));
+    /// let res = client.create_token(&opts).unwrap();
     /// let mut new_client = Client::new(host, &res.client_token).unwrap();
     ///
     /// // Issue and use a bunch of temporary dynamic credentials.
@@ -568,7 +570,6 @@ impl<'a, T> VaultClient<'a, T>
     /// let client = Client::new(host, token).unwrap();
     ///
     /// let opts = client::TokenOptions::default()
-    ///   .id("test123456-test-create-token")
     ///   .display_name("test_token")
     ///   .policies(vec!("root"))
     ///   .default_policy(false)

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -484,7 +484,7 @@ impl<'a, T> VaultClient<'a, T>
     /// # fn main() {
     /// let host = "http://127.0.0.1:8200";
     /// let token = "test12345";
-    /// let mut client = Client::new(host, token).unwrap();
+    /// let client = Client::new(host, token).unwrap();
     ///
     /// // Create a temporary token, and use it to create a new client.
     /// let res = client.create_token(&Default::default()).unwrap();
@@ -497,8 +497,11 @@ impl<'a, T> VaultClient<'a, T>
     /// # }
     /// ```
     ///
+    /// Note that we consume our `self` parameter, so you cannot use the
+    /// client after revoking it.
+    ///
     /// [token]: https://www.vaultproject.io/docs/auth/token.html
-    pub fn revoke(&mut self) -> Result<()> {
+    pub fn revoke(self) -> Result<()> {
         let _ = try!(self.post("/v1/auth/token/revoke-self", None));
         Ok(())
     }
@@ -512,7 +515,7 @@ impl<'a, T> VaultClient<'a, T>
     /// # fn main() {
     /// let host = "http://127.0.0.1:8200";
     /// let token = "test12345";
-    /// let mut client = Client::new(host, token).unwrap();
+    /// let client = Client::new(host, token).unwrap();
     ///
     /// // TODO: Right now, we offer no way to get lease information for a
     /// // secret.
@@ -539,7 +542,7 @@ impl<'a, T> VaultClient<'a, T>
     /// # fn main() {
     /// let host = "http://127.0.0.1:8200";
     /// let token = "test12345";
-    /// let mut client = Client::new(host, token).unwrap();
+    /// let client = Client::new(host, token).unwrap();
     ///
     /// let res = client.lookup().unwrap();
     /// assert!(res.data.unwrap().policies.len() >= 0);
@@ -547,7 +550,7 @@ impl<'a, T> VaultClient<'a, T>
     /// ```
     ///
     /// [token]: https://www.vaultproject.io/docs/auth/token.html
-    pub fn lookup(&mut self) -> Result<VaultResponse<TokenData>> {
+    pub fn lookup(&self) -> Result<VaultResponse<TokenData>> {
         let mut res = try!(self.get("/v1/auth/token/lookup-self", None));
         let vault_res: VaultResponse<TokenData> = try!(parse_vault_response(&mut res));
         Ok(vault_res)
@@ -562,7 +565,7 @@ impl<'a, T> VaultClient<'a, T>
     /// # fn main() {
     /// let host = "http://127.0.0.1:8200";
     /// let token = "test12345";
-    /// let mut client = Client::new(host, token).unwrap();
+    /// let client = Client::new(host, token).unwrap();
     ///
     /// let opts = client::TokenOptions::default()
     ///   .id("test123456-test-create-token")
@@ -577,7 +580,7 @@ impl<'a, T> VaultClient<'a, T>
     ///   .explicit_max_ttl(client::VaultDuration::minutes(3));
     /// let res = client.create_token(&opts).unwrap();
     ///
-    /// # let mut new_client = Client::new(host, &res.client_token).unwrap();
+    /// # let new_client = Client::new(host, &res.client_token).unwrap();
     /// # new_client.revoke().unwrap();
     /// # }
     /// ```


### PR DESCRIPTION
There's a number of details worth mentioning here:
1. This allows us to enable the test case for `revoke`!
2. Token creating has a long and ever-growing list of parameters.  To accomomdate this, I define a `TokenOptions` struct that works as a builder type. Users ceate a new `TokenOptions` struct, and then call a series of chained methods to set individual options.  This is a reasonably common Rust pattern.
3. The `TokenOptions` builder methods make fairly aggressive use of `Into`, allowing you to pass in `&str`, `String`, etc.  This is similar to `std::process::Command`.
4. For consistency, I use the existing `VaultDuration` type to specify TTLs when creating a new token.  But I allow for improved API ergonomics by accepting `Into<VaultDuration>`, so that we could accept `std::time::Duration`, `chrono::Duration` or even just bare seconds by defining appropriate `From<T>` implementations for `VaultDuration`.
5. I include an an API change to `revoke` that (a) removes the need to declare `let mut client`, and (b) prevents the user from accessing a client that they've already revoked.
6. I also remove a bunch of unnecessary `mut` declarations.

As always, your feedback is welcome!
