### PR TITLE
Remove unused lifetime detected by Clippy

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -301,7 +301,7 @@ impl TokenOptions {
     /// the created token.  Unless you also call `default_policy(false)`, the
     /// policy `default` will be added to this list in modern versions of
     /// vault.
-    pub fn policies<'a, I>(mut self, policies: I) -> Self
+    pub fn policies<I>(mut self, policies: I) -> Self
         where I: IntoIterator,
               I::Item: Into<String>
     {


### PR DESCRIPTION
(This is a low-priority fix to one of my recent PRs. It shouldn't affect any users; no need to release a new version right away.)

Found using `rustup run nightly cargo clippy`.  This was an artifact from an earlier version of this API.
