### PR TITLE
Secret paths shoudn't be hardcoded since vault supports mounting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,58 +33,64 @@ pub use client::error::Error;
 #[cfg(test)]
 mod tests {
     use client::VaultClient as Client;
+    use std::env;
 
     #[test]
     fn it_can_create_a_client() {
-        let host = "http://127.0.0.1:8200";
-        let token = "test12345";
-        let _ = Client::new(host, token).unwrap();
+        let host = env::var("VAULT_ADDR").unwrap_or("http://127.0.0.1:8200".to_string());
+        let token = env::var("VAULT_TOKEN").unwrap_or("test12345".to_string());
+        let _ = Client::new(&host, &token).unwrap();
     }
+
 
     #[test]
     fn it_can_query_secrets() {
-        let host = "http://127.0.0.1:8200";
-        let token = "test12345";
-        let client = Client::new(host, token).unwrap();
-        let res = client.set_secret("hello_query", "world");
+        let host = env::var("VAULT_ADDR").unwrap_or("http://127.0.0.1:8200".to_string());
+        let token = env::var("VAULT_TOKEN").unwrap_or("test12345".to_string());
+
+        let client = Client::new(&host, &token).unwrap();
+        let res = client.set_secret("secret/hello_query", "world");
         assert!(res.is_ok());
-        let res = client.get_secret("hello_query").unwrap();
+        let res = client.get_secret("secret/hello_query").unwrap();
         assert_eq!(res, "world");
     }
 
     #[test]
     fn it_can_write_secrets_with_newline() {
-        let host = "http://127.0.0.1:8200";
-        let token = "test12345";
-        let client = Client::new(host, token).unwrap();
+        let host = env::var("VAULT_ADDR").unwrap_or("http://127.0.0.1:8200".to_string());
+        let token = env::var("VAULT_TOKEN").unwrap_or("test12345".to_string());
 
-        let res = client.set_secret("hello_set", "world\n");
+        let client = Client::new(&host, &token).unwrap();
+        let res = client.set_secret("secret/hello_set", "world\n");
         assert!(res.is_ok());
-        let res = client.get_secret("hello_set").unwrap();
+        let res = client.get_secret("secret/hello_set").unwrap();
         assert_eq!(res, "world\n");
     }
+
     #[test]
     fn it_returns_err_on_forbidden() {
-        let host = "http://127.0.0.1:8200";
-        let token = "test123456";
-        let client = Client::new(host, token);
+        let host = env::var("VAULT_ADDR").unwrap_or("http://127.0.0.1:8200".to_string());
+        let token = "I'ma bad guy";
+        let client = Client::new(&host, token);
+
         // assert_eq!(Err("Forbidden".to_string()), client);
         assert!(client.is_err());
     }
 
     #[test]
     fn it_can_delete_a_secret() {
-        let host = "http://127.0.0.1:8200";
-        let token = "test12345";
-        let client = Client::new(host, token).unwrap();
 
-        let res = client.set_secret("hello_delete", "world");
+        let host = env::var("VAULT_ADDR").unwrap_or("http://127.0.0.1:8200".to_string());
+        let token = env::var("VAULT_TOKEN").unwrap_or("test12345".to_string());
+        let client = Client::new(&host, &token).unwrap();
+
+        let res = client.set_secret("secret/hello_delete", "world");
         assert!(res.is_ok());
-        let res = client.get_secret("hello_delete").unwrap();
+        let res = client.get_secret("secret/hello_delete").unwrap();
         assert_eq!(res, "world");
-        let res = client.delete_secret("hello_delete");
+        let res = client.delete_secret("secret/hello_delete");
         assert!(res.is_ok());
-        let res = client.get_secret("hello_delete");
+        let res = client.get_secret("secret/hello_delete");
         assert!(res.is_err());
     }
 }


### PR DESCRIPTION
Secrets can be anywhere depending of mount types, so secret paths shouldn't be hardcoded into paths.
Also added convenience examples for taking settings from environment variables like mainstream client does.
Fixed some tests that didn't work on my vault -dev instance because some tokens required root token privileges.
