### PR TITLE
fix(url): take any version 1.x version >= 1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1.0"
 reqwest = "~0.6"
 log = "0.3"
 quick-error = "1.1.0"
-url = "~1.4"
+url = "1.4"
 
 [dependencies.clippy]
 optional = true


### PR DESCRIPTION
One more simple one here. Since url is "1.0" we don't need to lock into the minor version.