### PR TITLE
transit: add encrypt and decrypt primitives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ notifications:
 before_script:
 - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 - VAULT_ADDR=http://127.0.0.1:8200 vault token-create -id="test12345" -ttl="720h"
+- VAULT_ADDR=http://127.0.0.1:8200 vault mount transit
+- VAULT_ADDR=http://127.0.0.1:8200 vault write -f transit/keys/test-vault-rs
 install:
 - travis_retry bin/install-vault-${VAULT_BRANCH}.sh
 - export PATH=$HOME/bin:$PATH

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 repository = "https://github.com/chrismacnaughton/vault-rs"
 
 [dependencies]
+base64 = "~0.7"
 chrono = "~0.4"
 hyper = "~0.11"
 serde = "1.0.16"

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -38,5 +38,12 @@ quick_error! {
             display("url parse error: {}", err)
             cause(err)
         }
+        /// `Base64` decode error
+        Base64(err: ::base64::DecodeError) {
+            from()
+                description("base64 decode error")
+                display("base64 decode error: {}", err)
+                cause(err)
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 
 //! Client API for interacting with [Vault](https://www.vaultproject.io/docs/http/index.html)
 
+extern crate base64;
 extern crate reqwest;
 #[macro_use]
 extern crate hyper;
@@ -292,6 +293,19 @@ mod tests {
             }
             _ => panic!("expected vault response, got: {:?}", res),
         }
+    }
+
+    #[test]
+    fn it_can_encrypt_decrypt_transit() {
+        let key_id = "test-vault-rs";
+        let plaintext = b"data\0to\0encrypt";
+
+        let client = Client::new(HOST, TOKEN).unwrap();
+        let enc_resp = client.transit_encrypt(None, key_id, plaintext);
+        let encrypted = enc_resp.unwrap();
+        let dec_resp = client.transit_decrypt(None, key_id, encrypted);
+        let payload = dec_resp.unwrap();
+        assert_eq!(plaintext, payload.as_slice());
     }
 
     // helper fn to panic on empty responses


### PR DESCRIPTION
This adds encryption and decryption support using the Transit
secret backend, together with a simple roundtrip test.