### PR TITLE
Updated dependencies + Vault 1.3 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hashicorp_vault"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2018"
 authors = [
   "Chris MacNaughton <chmacnaughton@gmail.com>",
@@ -30,3 +30,4 @@ version = "^0.0"
 default = ["vault_0_6_2"]
 "vault_0_6_1" = []
 "vault_0_6_2" = ["vault_0_6_1"]
+"vault_1_3" = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,16 @@ license = "MIT"
 repository = "https://github.com/chrismacnaughton/vault-rs"
 
 [dependencies]
-base64 = "~0.7"
+base64 = "~0.11"
 chrono = "~0.4"
-hyper = "~0.11"
-serde = "1.0.16"
-serde_derive = "1.0.16"
-serde_json = "1.0.4"
-reqwest = "~0.9"
-log = "0.3.8"
-quick-error = "1.2.1"
-url = "1.5.1"
+hyper = "~0.13"
+serde = { version = "1.0.104", features = ["derive"] }
+serde_derive = "1.0.104"
+serde_json = "1.0.48"
+reqwest = { version = "~0.10", features = ["blocking"] }
+log = "0.4.8"
+quick-error = "1.2.3"
+url = "2.1.1"
 
 [dependencies.clippy]
 optional = true

--- a/README.md
+++ b/README.md
@@ -3,10 +3,21 @@
 
 [HashiCorp](https://hashicorp.com/) [Vault](https://www.vaultproject.io) API client for Rust.
 
+
+```toml
+hashicorp_vault = "0.7"
+```
+
+## Local server
 You can start a local test server running using:
 
 ```bash
+# Pre-1.0 versions of Vault w/ kv secrets v1 only
 vault server -dev
+
+# v1.0.1+ versions of Vault w/ kv secrets v2 as default dev mode
+# See: https://github.com/hashicorp/vault/pull/5919
+vault server -dev-kv-v1
 ```
 
 Record the `Root Token:` printed at startup time, and use it to create a
@@ -18,6 +29,18 @@ export VAULT_TOKEN=<root token from server startup>
 vault token-create -id="test12345" -ttl="720h"
 ```
 
+Or you can use the provided `docker-compose.yml` to start a containerized vault.
+
+```bash
+docker-compose up -d
+export VAULT_ADDR=http://127.0.0.1:8200
+export VAULT_TOKEN=vault
+vault token create -id="test12345" -ttl="720h"
+
+# You need to enable the transit secrets engine for `cargo test`
+vault secrets enable transit
+```
+
 ## High Availability
 
 To use this with a highly available vault, you need to either let consul handle DNS for this crate or handle identifying the Vault leader separately.
@@ -25,3 +48,12 @@ To use this with a highly available vault, you need to either let consul handle 
 ## TODO
 
 - Add support for managing Vault
+
+## Features
+### Vault 1.3.x support
+
+You can enable the `vault_1_3` feature in your `Cargo.toml`
+
+```toml
+hashicorp_vault = { version = "0.7", features = ["vault_1_3"] }
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+services: 
+  vault:
+    image: vault:1.3.3
+    container_name: vault
+    hostname: vault-docker
+    ports:
+      - 8200:8200
+    environment:
+      - VAULT_DEV_ROOT_TOKEN_ID=vault
+      - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
+      - VAULT_LOCAL_CONFIG
+    cap_add:
+      - IPC_LOCK
+    command:
+      - vault
+      - server
+      - -dev-kv-v1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,8 @@
 //! Client API for interacting with [Vault](https://www.vaultproject.io/docs/http/index.html)
 
 extern crate base64;
-extern crate reqwest;
-#[macro_use]
 extern crate hyper;
+extern crate reqwest;
 #[macro_use]
 extern crate log;
 #[macro_use]


### PR DESCRIPTION
* Updated all the dependencies + bumped version to `0.7.1`
* Ran `cargo fmt`
* Added minimal support for Vault 1.3 (including tests) w/ a new feature flag `vault_1_3`
* Added docker-compose.yml that can be used for development, and `cargo test`
* Updated README.md

No new logic added while updating all the dependencies and getting the tests working w/ a Vault 1.3 server. Support is added via feature flag, but the default is the same.