### PR TITLE
Updating for vault 1.3.3 which has a number of breaking changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,7 @@ matrix:
   fast_finish: true
 env:
   matrix:
-  - VAULT_VERSION=0.6.0 VAULT_BRANCH=release TRAVIS_CARGO_NIGHTLY_FEATURE=""
-  - VAULT_VERSION=0.6.1 VAULT_BRANCH=release TRAVIS_CARGO_NIGHTLY_FEATURE=""
-  - VAULT_VERSION=0.6.2 VAULT_BRANCH=release TRAVIS_CARGO_NIGHTLY_FEATURE=""
-  - VAULT_VERSION=0.7.2 VAULT_BRANCH=release TRAVIS_CARGO_NIGHTLY_FEATURE=""
+  - VAULT_VERSION=1.3.3 VAULT_BRANCH=release TRAVIS_CARGO_NIGHTLY_FEATURE=""
   global:
     secure: SQxIo2LX+e5nTKKZ2I0Ix2BIfo5Q3xPaLv9mrvKf/aPvaqh/Z4LPS6l3MgOiqKx0zJBH/QHfqO8IUoQrDpq4Fu609Yo9nU6FCPsbjYOhOgQ2+XNzmLX389q2SNBZirae8U5pm4VVXAO4abnUv7mDImje8AubYVRGDXv0XsSlJtPlyPVdqxz0a52k4qg4Jzf8K+x1RZy/O8bwSCCgwgjqm2zLOn/3MFSAH3jxHaAg5i8fxmjCOd8sAIEZvHL0U7H9X0wprirLZxGegFyp5+wU+IiPmJNG88kJJ3ylGCz2ynzkreijYUvbpmfOlmMOQU5rq0SbDUOTFA2Muqnt53d6SCWjFWbrQksDS8MNpu2rVNCm+pmVdGIRYBdpY5QqYyA7Cbu65GqJkorwCOT6U6XK4UO+5V5ICXaXTvz4buzGVzK8UBYwl5jrFrNKud+FyckaDeU7wNIYH7meQ/Qf6zJtwHl9AH+yTW9bCk42lo+JCjowElGCfKULC1n09tvhoBNlTvd+8yICz3nAXvMD5peDJ4H8dMPgDtyKOl1+lTBccUTD5EtkaLgoahPEH7R1hC+PzbUy1+YeG3G+qoG90T+sso/DjSD6sKtDten8AqYeB0g9gWbenzsnMsfoz/GqpV0haxrGFw5/QbCnaOSGFKDzy5iks72oJ8HdOiX5sNKX6S8=
 cache:
@@ -35,7 +32,7 @@ notifications:
 before_script:
 - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 - VAULT_ADDR=http://127.0.0.1:8200 vault token-create -id="test12345" -ttl="720h"
-- VAULT_ADDR=http://127.0.0.1:8200 vault mount transit
+- VAULT_ADDR=http://127.0.0.1:8200 vault secrets enable transit
 - VAULT_ADDR=http://127.0.0.1:8200 vault write -f transit/keys/test-vault-rs
 install:
 - travis_retry bin/install-vault-${VAULT_BRANCH}.sh
@@ -43,11 +40,7 @@ install:
 - vault server -dev > /dev/null 2>&1 &
 script:
   - |
-      if [[ $VAULT_VERSION == 0.6.0 ]]; then
-        cargo test --verbose --no-default-features
-      elif [[ $VAULT_VERSION == 0.6.1 ]]; then
-        cargo test --verbose --no-default-features --features "vault_0_6_1"
-      elif [[ $TRAVIS_RUST_VERSION = nightly ]]; then
+      if [[ $TRAVIS_RUST_VERSION = nightly ]]; then
         cargo test --verbose --features "clippy"
       else
         cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ notifications:
     on_success: never
 before_script:
 - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
-- VAULT_ADDR=http://127.0.0.1:8200 vault token-create -id="test12345" -ttl="720h"
+- VAULT_ADDR=http://127.0.0.1:8200 vault token create -id="test12345" -ttl="720h"
 - VAULT_ADDR=http://127.0.0.1:8200 vault secrets enable transit
 - VAULT_ADDR=http://127.0.0.1:8200 vault write -f transit/keys/test-vault-rs
 install:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,22 +11,17 @@ license = "MIT"
 repository = "https://github.com/chrismacnaughton/vault-rs"
 
 [dependencies]
-base64 = "~0.7"
+base64 = "~0.12"
 chrono = "~0.4"
 hyper = "~0.11"
-serde = "1.0.16"
-serde_derive = "1.0.16"
-serde_json = "1.0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_derive = "1.0"
+serde_json = "1.0"
 reqwest = "~0.9"
-log = "0.3.8"
-quick-error = "1.2.1"
+log = "0.4.8"
+quick-error = "1.2.3"
 url = "1.5.1"
 
 [dependencies.clippy]
 optional = true
 version = "^0.0"
-
-[features]
-default = ["vault_0_6_2"]
-"vault_0_6_1" = []
-"vault_0_6_2" = ["vault_0_6_1"]

--- a/bin/install-vault-release.sh
+++ b/bin/install-vault-release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux
 
-VAULT_VERSION=${VAULT_VERSION:-0.6.1}
+VAULT_VERSION=${VAULT_VERSION:-1.3.3}
 
 mkdir -p $HOME/bin
 

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -24,6 +24,12 @@ quick_error! {
             description("vault error")
             display("vault error: {}", err)
         }
+        /// Response from Vault errors
+        /// This is for when the response is not successful.
+        VaultResponse(err: String, response: reqwest::Response) {
+            description("vault response error")
+            display("Error in vault response: {}", err)
+        }
         /// IO errors
         Io(err: ::std::io::Error) {
             from()

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -406,7 +406,7 @@ pub struct AppRoleProperties {
     pub bind_secret_id: bool,
     /// The secret IDs generated using this role will be cluster local.
     pub local_secret_ids: bool,
-    /// Vector of CIDR blocks; if set, specifies blocks of IP addresses which can
+    /// List of CIDR blocks; if set, specifies blocks of IP addresses which can
     /// perform the login operation.
     pub secret_id_bound_cidrs: Option<Vec<String>>,
     /// Number of times any particular `SecretID` can be used to fetch a token from this `AppRole`,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -109,7 +109,7 @@ pub enum VaultNumUses {
 
     /// The number of uses is limited to the value
     /// specified that is guaranteed to be non zero.
-    Limited(NonZeroU64)
+    Limited(NonZeroU64),
 }
 
 impl From<u64> for VaultNumUses {
@@ -1469,10 +1469,13 @@ fn handle_hyper_response(res: StdResult<Response, reqwest::Error>) -> Result<Res
             error_msg.push_str("Could not read vault response.");
             0
         });
-        Err(Error::Vault(format!(
-            "Vault request failed: {:?}, error message: `{}`",
-            res, error_msg
-        )))
+        Err(Error::VaultResponse(
+            format!(
+                "Vault request failed: {:?}, error message: `{}`",
+                res, error_msg
+            ),
+            res,
+        ))
     }
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -112,6 +112,10 @@ pub enum VaultNumUses {
     Limited(NonZeroU64),
 }
 
+impl Default for VaultNumUses {
+    fn default() -> Self { VaultNumUses::Unlimited }
+}
+
 impl From<u64> for VaultNumUses {
     fn from(v: u64) -> Self {
         match NonZeroU64::new(v) {
@@ -402,7 +406,7 @@ pub struct AppRoleProperties {
     pub bind_secret_id: bool,
     /// The secret IDs generated using this role will be cluster local.
     pub local_secret_ids: bool,
-    /// Comma-separated list of CIDR blocks; if set, specifies blocks of IP addresses which can
+    /// Vector of CIDR blocks; if set, specifies blocks of IP addresses which can
     /// perform the login operation.
     pub secret_id_bound_cidrs: Option<Vec<String>>,
     /// Number of times any particular `SecretID` can be used to fetch a token from this `AppRole`,
@@ -421,7 +425,7 @@ pub struct AppRoleProperties {
     pub token_no_default_policy: bool,
     /// Duration after which the issued token can no longer be renewed.
     pub token_max_ttl: VaultDuration,
-    /// The maximum number of times a generated token may be used (within its lifetime); 0 means unlimited.
+    /// The maximum number of times a generated token may be used (within its lifetime).
     pub token_num_uses: VaultNumUses,
     /// The incremental lifetime for generated tokens.
     /// If set, the token generated using this `AppRole` is a periodic token; so long as it is
@@ -531,7 +535,7 @@ pub struct TokenOptions {
     ttl: Option<String>,
     explicit_max_ttl: Option<String>,
     display_name: Option<String>,
-    num_uses: Option<VaultNumUses>,
+    num_uses: VaultNumUses,
 }
 
 impl TokenOptions {
@@ -586,7 +590,7 @@ impl TokenOptions {
 
     /// How many times can this token be used before it stops working?
     pub fn number_of_uses<D: Into<VaultNumUses>>(mut self, uses: D) -> Self {
-        self.num_uses = Some(uses.into());
+        self.num_uses = uses.into();
         self
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -115,8 +115,8 @@ pub enum VaultNumUses {
 impl From<u64> for VaultNumUses {
     fn from(v: u64) -> Self {
         match NonZeroU64::new(v) {
-            Some(non_zero) => Self::Limited(non_zero),
-            None => Self::Unlimited,
+            Some(non_zero) => VaultNumUses::Limited(non_zero),
+            None => VaultNumUses::Unlimited,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "vault_0_6_2")]
     fn it_can_read_a_wrapped_secret() {
         let client = Client::new(HOST, TOKEN).unwrap();
         let res = client.set_secret("hello_delete_2", "second world");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,8 @@ mod tests {
     use crate::client::HttpVerb::*;
     use crate::client::VaultClient as Client;
     use crate::client::{self, EndpointResponse};
+    use crate::Error;
+    use reqwest::StatusCode;
 
     /// vault host for testing
     const HOST: &str = "http://127.0.0.1:8200";
@@ -139,6 +141,20 @@ mod tests {
         let res = client.list_secrets("hello/");
         assert!(res.is_ok());
         assert_eq!(res.unwrap(), ["bob", "fred"]);
+    }
+
+    #[test]
+    fn it_can_detect_404_status() {
+        let client = Client::new(HOST, TOKEN).unwrap();
+
+        let res = client.list_secrets("non/existent/key");
+        assert!(res.is_err());
+
+        if let Err(Error::VaultResponse(_, response)) = res {
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        } else {
+            panic!("Error should match on VaultResponse with reqwest response.");
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,6 @@ extern crate log;
 extern crate quick_error;
 pub extern crate chrono;
 extern crate serde;
-extern crate serde_derive;
-extern crate serde_json;
 pub extern crate url;
 
 /// vault client
@@ -126,6 +124,24 @@ mod tests {
     }
 
     #[test]
+    fn it_can_list_secrets() {
+        let client = Client::new(HOST, TOKEN).unwrap();
+
+        let _res = client.set_secret("hello/fred", "world").unwrap();
+        // assert!(res.is_ok());
+        let res = client.set_secret("hello/bob", "world");
+        assert!(res.is_ok());
+
+        let res = client.list_secrets("hello");
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap(), ["bob", "fred"]);
+
+        let res = client.list_secrets("hello/");
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap(), ["bob", "fred"]);
+    }
+
+    #[test]
     fn it_can_write_secrets_with_newline() {
         let client = Client::new(HOST, TOKEN).unwrap();
 
@@ -157,7 +173,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "vault_0_6_1")]
     fn it_can_perform_approle_workflow() {
         use std::collections::HashMap;
 
@@ -177,7 +192,7 @@ mod tests {
         panic_non_empty(&res);
 
         // let test the properties endpoint while we're here
-        assert!(c.get_app_role_properties("test_role").is_ok());
+        let _ = c.get_app_role_properties("test_role").unwrap();
 
         // get approle's role-id
         let res: EndpointResponse<HashMap<String, String>> = c
@@ -230,7 +245,7 @@ mod tests {
     fn it_can_store_policies() {
         // use trailing slash for host to ensure Url processing fixes this later
         let c = Client::new("http://127.0.0.1:8200/", TOKEN).unwrap();
-        let body = "{\"rules\":\"{}\"}";
+        let body = "{\"policy\":\"{}\"}";
         // enable approle auth backend
         let res: EndpointResponse<()> = c
             .call_endpoint(PUT, "sys/policy/test_policy_1", None, Some(body))
@@ -280,7 +295,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "vault_0_6_1")]
     fn it_can_list_things() {
         let c = Client::new(HOST, TOKEN).unwrap();
         let _ = c


### PR DESCRIPTION
I was looking to add functionality to the client, but found it wasn't working with the latest version of vault.

Unfortunately based on vault's text regarding keeping backwards compatibility it seemed to not warrant maintaining the old version of the code base. As there are a number of breaking changes and not an endpoint to maintain it. The biggest one being the `/secret/` end point no longer serves up the data and has changed to `/secret/data`. 

> Backwards compatibility: At the current version, Vault does not yet promise backwards compatibility even with the v1 prefix. We'll remove this warning when this policy changes. At this point in time the core API (that is, sys/ routes) change very infrequently, but various secrets engines/auth methods/etc. sometimes have minor changes to accommodate new features as they're developed.

I've also added a `list_secrets` for retrieving the keys at a particular path location. I'd appreciate a published crate as I want to use this in a private crate repo, and I'm not able to publish a crate that references a git hash.