### PR TITLE
cargo-audit showed a vulnerability on an old version of hyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/chrismacnaughton/vault-rs"
 [dependencies]
 base64 = "~0.12"
 chrono = "~0.4"
-hyper = "~0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -239,7 +239,7 @@ pub struct VaultClient<T> {
     pub host: Url,
     /// Token to access vault
     pub token: String,
-    /// `hyper::Client`
+    /// `reqwest::Client`
     client: Client,
     /// Data
     pub data: Option<VaultResponse<T>>,
@@ -630,21 +630,6 @@ pub enum EndpointResponse<D> {
     VaultResponse(VaultResponse<D>),
     /// Empty, but still successful response
     Empty,
-}
-
-header! {
-    /// Token used to authenticate with the vault API
-    (XVaultToken, "X-Vault-Token") => [String]
-}
-header! {
-    /// The TTL for the token is set by the client using the `X-Vault-Wrap-TTL` header and can be
-    /// either an integer number of seconds or a string duration of seconds (15s), minutes (20m),
-    /// or hours (25h). When using the Vault CLI, you can set this via the -wrap-ttl parameter.
-    /// Response wrapping is per-request; it is the presence of a value in this header that
-    /// activates wrapping of the response.
-    ///
-    /// See: https://www.vaultproject.io/docs/secrets/cubbyhole/index.html
-    (XVaultWrapTTL, "X-Vault-Wrap-TTL") => [String]
 }
 
 impl VaultClient<TokenData> {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -641,7 +641,7 @@ impl VaultClient<TokenData> {
         let host = host.try_into()?;
         let client = Client::new();
         let token = token.into();
-        let res = handle_hyper_response(
+        let res = handle_reqwest_response(
             client
                 .get(host.join("/v1/auth/token/lookup-self")?)
                 .header("X-Vault-Token", token.clone())
@@ -677,7 +677,7 @@ impl VaultClient<()> {
             app_id: app_id.into(),
             user_id: user_id.into(),
         })?;
-        let res = handle_hyper_response(
+        let res = handle_reqwest_response(
             client
                 .post(host.join("/v1/auth/app-id/login")?)
                 .body(payload)
@@ -723,7 +723,7 @@ impl VaultClient<()> {
             role_id: role_id.into(),
             secret_id,
         })?;
-        let res = handle_hyper_response(
+        let res = handle_reqwest_response(
             client
                 .post(host.join("/v1/auth/approle/login")?)
                 .body(payload)
@@ -1313,7 +1313,7 @@ where
     ) -> Result<Response> {
         let h = self.host.join(endpoint.as_ref())?;
         match wrap_ttl {
-            Some(wrap_ttl) => Ok(handle_hyper_response(
+            Some(wrap_ttl) => Ok(handle_reqwest_response(
                 self.client
                     .request(Method::GET, h)
                     .header("X-Vault-Token", self.token.to_string())
@@ -1321,7 +1321,7 @@ where
                     .header("X-Vault-Wrap-TTL", wrap_ttl.into())
                     .send(),
             )?),
-            None => Ok(handle_hyper_response(
+            None => Ok(handle_reqwest_response(
                 self.client
                     .request(Method::GET, h)
                     .header("X-Vault-Token", self.token.to_string())
@@ -1332,7 +1332,7 @@ where
     }
 
     fn delete<S: AsRef<str>>(&self, endpoint: S) -> Result<Response> {
-        Ok(handle_hyper_response(
+        Ok(handle_reqwest_response(
             self.client
                 .request(Method::DELETE, self.host.join(endpoint.as_ref())?)
                 .header("X-Vault-Token", self.token.to_string())
@@ -1354,7 +1354,7 @@ where
             String::new()
         };
         match wrap_ttl {
-            Some(wrap_ttl) => Ok(handle_hyper_response(
+            Some(wrap_ttl) => Ok(handle_reqwest_response(
                 self.client
                     .request(Method::POST, h)
                     .header("X-Vault-Token", self.token.to_string())
@@ -1363,7 +1363,7 @@ where
                     .body(body)
                     .send(),
             )?),
-            None => Ok(handle_hyper_response(
+            None => Ok(handle_reqwest_response(
                 self.client
                     .request(Method::POST, h)
                     .header("X-Vault-Token", self.token.to_string())
@@ -1387,7 +1387,7 @@ where
             String::new()
         };
         match wrap_ttl {
-            Some(wrap_ttl) => Ok(handle_hyper_response(
+            Some(wrap_ttl) => Ok(handle_reqwest_response(
                 self.client
                     .request(Method::PUT, h)
                     .header("X-Vault-Token", self.token.to_string())
@@ -1396,7 +1396,7 @@ where
                     .body(body)
                     .send(),
             )?),
-            None => Ok(handle_hyper_response(
+            None => Ok(handle_reqwest_response(
                 self.client
                     .request(Method::PUT, h)
                     .header("X-Vault-Token", self.token.to_string())
@@ -1420,7 +1420,7 @@ where
             String::new()
         };
         match wrap_ttl {
-            Some(wrap_ttl) => Ok(handle_hyper_response(
+            Some(wrap_ttl) => Ok(handle_reqwest_response(
                 self.client
                     .request(
                         Method::from_str("LIST".into()).expect("Failed to parse LIST to Method"),
@@ -1432,7 +1432,7 @@ where
                     .body(body)
                     .send(),
             )?),
-            None => Ok(handle_hyper_response(
+            None => Ok(handle_reqwest_response(
                 self.client
                     .request(
                         Method::from_str("LIST".into()).expect("Failed to parse LIST to Method"),
@@ -1448,7 +1448,7 @@ where
 }
 
 /// helper fn to check `Response` for success
-fn handle_hyper_response(res: StdResult<Response, reqwest::Error>) -> Result<Response> {
+fn handle_reqwest_response(res: StdResult<Response, reqwest::Error>) -> Result<Response> {
     let mut res = res?;
     if res.status().is_success() {
         Ok(res)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,6 @@
 extern crate base64;
 extern crate reqwest;
 #[macro_use]
-extern crate hyper;
-#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate quick_error;


### PR DESCRIPTION
Downstream I noticed an error in our `cargo audit` run from the version of hyper used in this crate.

Running `cargo-audit` in this repo before my PR resulted in the following:
```
error: Vulnerable crates found!

ID:       RUSTSEC-2020-0008
Crate:    hyper
Version:  0.11.27
Date:     2020-03-19
URL:      https://rustsec.org/advisories/RUSTSEC-2020-0008
Title:    Flaw in hyper allows request smuggling by sending a body in GET requests
Solution:  upgrade to >= 0.12.34
Dependency tree: 
hyper 0.11.27

warning: 1 warning found

Crate:  term
Title:  term is looking for a new maintainer
Date:   2018-11-19
URL:    https://rustsec.org/advisories/RUSTSEC-2018-0015
Dependency tree: 
term 0.5.2
└── clippy 0.0.302
    └── hashicorp_vault 0.7.0
```

I noticed that hyper is not really being used thanks to the PR from tjtelan: https://github.com/ChrisMacNaughton/vault-rs/pull/32/

So I removed hyper. I noticed clippy is at latest version, and so not much I can do for the latter unless removing the clippy dependency.
