### PR TITLE
VaultClient::escape() escapes double quotes when encoding secrets

### DIFF
--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,0 +1,13 @@
+extern crate hashicorp_vault as vault;
+
+fn main() {
+    let host = "http://localhost:8200";
+    let token = "test12345";
+    let client = vault::Client::new(host, token).unwrap();
+
+    let _ = client.set_secret("foo", "{\"bar\": \"baz\"}");
+
+    let secret = client.get_secret("foo").unwrap();
+
+    println!("Secret \"foo\" is: {}", secret);
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -980,7 +980,9 @@ where
     }
 
     fn escape<S: AsRef<str>>(&self, input: S) -> String {
-        input.as_ref().replace("\n", "\\n")
+        input.as_ref()
+            .replace("\n", "\\n")
+            .replace("\"", "\\\"")
     }
 
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,16 @@ mod tests {
     }
 
     #[test]
+    fn it_can_store_json_secrets() {
+        let client = Client::new(HOST, TOKEN).unwrap();
+        let json = "{\"foo\": {\"bar\": [\"baz\"]}}";
+        let res = client.set_secret("json_secret", json);
+        assert!(res.is_ok());
+        let res = client.get_secret("json_secret").unwrap();
+        assert_eq!(res, json)
+    }
+
+    #[test]
     fn it_can_list_secrets() {
         let client = Client::new(HOST, TOKEN).unwrap();
 


### PR DESCRIPTION
This enables us to store json strings in Vault without issue.

Test and example were added to prove use case.