### PR TITLE
Add support for custom secret types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ FEATURES
 
 - Update tested Vault releases to include latest versions.
 - Migrate CI testing to Github actions.
+- Add support for custoim secret types (https://github.com/ChrisMacNaughton/vault-rs/pull/44).
+  
+  The new secret types allow for managing arbitrary data in Vault
+  as long as the data is serializable!
 
 BREAKING CHANGES
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@ mod tests {
     use crate::client::{self, EndpointResponse};
     use crate::Error;
     use reqwest::StatusCode;
+    use serde::{Deserialize, Serialize};
 
     /// vault host for testing
     const HOST: &str = "http://127.0.0.1:8200";
@@ -391,5 +392,24 @@ mod tests {
             EndpointResponse::Empty => {}
             _ => panic!("expected empty response, received: {:?}", res),
         }
+    }
+
+    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    struct CustomSecretType {
+        name: String,
+    }
+
+    #[test]
+    fn it_can_set_and_get_a_custom_secret_type() {
+        let input = CustomSecretType {
+            name: "test".into(),
+        };
+
+        let client = Client::new(HOST, TOKEN).unwrap();
+
+        let res = client.set_custom_secret("custom_type", &input);
+        assert!(res.is_ok());
+        let res: CustomSecretType = client.get_custom_secret("custom_type").unwrap();
+        assert_eq!(res, input);
     }
 }


### PR DESCRIPTION
This change additionally refactors the default secret methods,
`get_secret` and `set_secret` to use the new custom get and set
methods with a new internal type.

Closes #42

