### PR TITLE
Update reqwest dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ chrono = "~0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
-reqwest = "~0.9"
+reqwest = { version = "~0.10", features = ["blocking"] }
 log = "0.4.8"
 quick-error = "1.2.3"
-url = "1.5.1"
+url = "2.2.0"
 
 [dependencies.clippy]
 optional = true

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -26,7 +26,7 @@ quick_error! {
         }
         /// Response from Vault errors
         /// This is for when the response is not successful.
-        VaultResponse(err: String, response: reqwest::Response) {
+        VaultResponse(err: String, response: reqwest::blocking::Response) {
             description("vault response error")
             display("Error in vault response: {}", err)
         }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -7,7 +7,12 @@ use std::str::FromStr;
 
 use crate::client::error::{Error, Result};
 use base64;
-use reqwest::{self, header::CONTENT_TYPE, Client, Method, Response};
+use reqwest::{
+    self,
+    blocking::{Client, Response},
+    header::CONTENT_TYPE,
+    Method,
+};
 use serde::de::{self, DeserializeOwned, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 


### PR DESCRIPTION
This addresses vulnerability [RUSTSEC-2021-0020](https://rustsec.org/advisories/RUSTSEC-2021-0020) reported by cargo-audit.

I have only updated to `reqwest 0.10` and not `0.11` because the latter depends on `tokio 1` and the async ecosystem hasn't fully migrated yet, so it seems useful to have a version supporting `tokio 0.2`. Maybe `hashicorp_vault 1.2` could use `tokio 0.2` and `hashicorp_vault 1.3` could switch to `tokio 1`? -- Note that I haven't checked if a minor or major bump should be done; I'd think `tokio` is not exposed by this crate because of its use of the blocking `reqwest` client.

Thank you.