### PR TITLE
Update dependencies (base64, reqwest, quick-error)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,14 @@ license = "MIT"
 repository = "https://github.com/chrismacnaughton/vault-rs"
 
 [dependencies]
-base64 = "~0.12"
+base64 = "~0.13"
 chrono = "~0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
-reqwest = { version = "~0.10", features = ["blocking"] }
+reqwest = { version = "~0.11", features = ["blocking"] }
 log = "0.4.8"
-quick-error = "1.2.3"
+quick-error = "~2.0"
 url = "2.2.0"
 
 [dependencies.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,18 @@ description = "HashiCorp Vault API client for Rust"
 license = "MIT"
 repository = "https://github.com/chrismacnaughton/vault-rs"
 
+[features]
+default = ["native-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+
 [dependencies]
 base64 = "~0.13"
 chrono = "~0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
-reqwest = { version = "~0.11", features = ["blocking"] }
+reqwest = { version = "~0.11", default-features = false, features = ["blocking"] }
 log = "0.4.8"
 quick-error = "~2.0"
 url = "2.2.0"

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -8,48 +8,41 @@ quick_error! {
         /// `reqwest::Error` errors
         Reqwest(err: ::reqwest::Error) {
             from()
-            description("reqwest error")
             display("reqwest error: {}", err)
-            cause(err)
+            source(err)
         }
         /// `serde_json::Error`
         SerdeJson(err: ::serde_json::Error) {
             from()
-            description("serde_json Error")
             display("serde_json Error: {}", err)
-            cause(err)
+            source(err)
         }
         /// Vault errors
         Vault(err: String) {
-            description("vault error")
             display("vault error: {}", err)
         }
         /// Response from Vault errors
         /// This is for when the response is not successful.
         VaultResponse(err: String, response: reqwest::blocking::Response) {
-            description("vault response error")
             display("Error in vault response: {}", err)
         }
         /// IO errors
         Io(err: ::std::io::Error) {
             from()
-            description("io error")
             display("io error: {}", err)
-            cause(err)
+            source(err)
         }
         /// `Url` parsing error
         Url(err: ::url::ParseError) {
             from()
-            description("url parse error")
             display("url parse error: {}", err)
-            cause(err)
+            source(err)
         }
         /// `Base64` decode error
         Base64(err: ::base64::DecodeError) {
             from()
-                description("base64 decode error")
-                display("base64 decode error: {}", err)
-                cause(err)
+            display("base64 decode error: {}", err)
+            source(err)
         }
     }
 }


### PR DESCRIPTION
Updated dependencies:
- base64 -> `~0.13`
- reqwest -> `~0.11`
- quick-error -> `~2.0`

I have also added features flags to select the TLS backend that reqwest uses - `native-tls` and `rustls-tls`. This should not be a breaking change as it defaults to `native-tls` which is in line with existing behavior.